### PR TITLE
Fix/datepicker text input readonly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@liquid-state/ui-kit-react-jsonschema-form",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "React JSON Schema Form widgets implemented with @liquid-state/ui-kit",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { DatePicker as AntDatePicker } from 'antd';
@@ -11,6 +11,15 @@ function DateWidget(props) {
     },
   } = props;
 
+  const setReadOnly = useCallback((open) => {
+    if (!open) return;
+
+    setTimeout(() => {
+      const d = document.querySelector('.ant-calendar-picker-container input');
+      d.setAttribute('readonly', true);
+    }, 10);
+  });
+
   if (navigator.userAgent.includes('Android')) {
     return (
       <AntDatePicker
@@ -19,6 +28,7 @@ function DateWidget(props) {
         onChange={date => props.onChange(date.format('YYYY-MM-DD'))}
         onBlur={props.onBlur && (event => props.onBlur(props.id, event.target.value))}
         onFocus={props.onFocus && (event => props.onFocus(props.id, event.target.value))}
+        onOpenChange={open => setReadOnly(open)}
       />
     );
   }

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -28,7 +28,7 @@ function DateWidget(props) {
         onChange={date => props.onChange(date.format('YYYY-MM-DD'))}
         onBlur={props.onBlur && (event => props.onBlur(props.id, event.target.value))}
         onFocus={props.onFocus && (event => props.onFocus(props.id, event.target.value))}
-        onOpenChange={open => setReadOnly(open)}
+        onOpenChange={setReadOnly}
       />
     );
   }


### PR DESCRIPTION
Implements workaround for setting the datepicker text input field to readonly to prevent mobile device focussing it, which activates the on-screen keyboard, covering the input or parts of the ui.

Note: version number has been incremented in this PR